### PR TITLE
Reobfuscation-based mods, mods that load early, a few definitions, and a 'loader branding mod'

### DIFF
--- a/assets/mods/loaderBranding/mod.js
+++ b/assets/mods/loaderBranding/mod.js
@@ -1,0 +1,28 @@
+(function () {
+	// Would prefer to extend (better code quality), but that means writing more definitions
+	var oldVersionToString = sc.version.toString.bind(sc.version);
+	sc.version.toString = function () {
+		return oldVersionToString() + " W/MODS";
+	};
+	// ----
+
+	var BrandingGameAddon = ig.GameAddon.extend({
+		init: function () {
+			this.parent("AddonThatAddsAKeySoDevsKnowIfASaveComesFromModdedCC");
+			ig.storage.register(this);
+		},
+		onStorageSave: function (a) {
+			a["ALERT_TO_CC_DEVS"] = "ALERT TO CROSSCODE DEVELOPERS: This save is from a modded version of the game. It is possible that the bug you are trying to track down may not be in the unmodified code. That said, it is also possible that the bug is in the unmodified code. Proceed with caution.";
+		},
+		// We don't have any reason to add these, but it's important to note they're there.
+		onStoragePreLoad: function (a) {
+		},
+		onStoragePostLoad: function (a) {
+		}
+	});
+
+	ig.addGameAddon(function () {
+		return new BrandingGameAddon();
+	});
+})();
+

--- a/assets/mods/loaderBranding/package.json
+++ b/assets/mods/loaderBranding/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "Loader Branding",
+	"main": "mod.js",
+	"reobf": true,
+	"executionTime": "postExecModules"
+}

--- a/ccloader/data/definitions.db
+++ b/ccloader/data/definitions.db
@@ -1743,6 +1743,32 @@
             "members": [
                 {
                     "type": "member",
+                    "refType": "var",
+                    "name": "CrossCode",
+                    "parent": "sc",
+                    "compiled": {
+                        "pattern": "arguments.2.property.name",
+                        "from": {
+                            "type": "CallExpression",
+                            "values": [
+                                {
+                                    "name": "arguments.0.value",
+                                    "value": "#canvas"
+                                },
+                                {
+                                    "name": "arguments.1.value",
+                                    "value": "#game"
+                                },
+                                {
+                                    "name": "arguments.2.object.name",
+                                    "value": "sc"
+                                }
+                            ]
+                        }
+                    }
+                },
+                {
+                    "type": "member",
                     "name": "PlayerConfig",
                     "refType": "var",
                     "parent": "sc",

--- a/ccloader/data/definitions.db
+++ b/ccloader/data/definitions.db
@@ -49,6 +49,7 @@
                     "type": "member",
                     "refType": "ref",
                     "name": "saveSlotList",
+                    "reobfName": "slots",
                     "parent": "cc.ig.storage",
                     "compiled": {
                         "type": "select",
@@ -87,6 +88,7 @@
                     "type": "member",
                     "refType": "var",
                     "name": "GUI",
+                    "reobfName": "gui",
                     "parent": "ig",
                     "compiled": {
                         "type": "select",
@@ -106,6 +108,7 @@
                     "type": "member",
                     "refType": "var",
                     "name": "gameMain",
+                    "reobfName": "game",
                     "parent": "ig",
                     "compiled": {
                         "type": "select",
@@ -144,6 +147,7 @@
                     "type": "member",
                     "refType": "var",
                     "name": "baseEntity",
+                    "reobfName": "Entity",
                     "parent": "ig",
                     "compiled": {
                         "type": "select",
@@ -163,6 +167,7 @@
                     "type": "member",
                     "refType": "var",
                     "name": "events",
+                    "reobfName": "EVENT_STEP",
                     "parent": "ig",
                     "compiled": {
                         "type": "select",
@@ -201,6 +206,7 @@
                     "type": "member",
                     "refType": "var",
                     "name": "combatActions",
+                    "reobfName": "ACTION_STEP",
                     "parent": "ig",
                     "compiled": {
                         "type": "select",
@@ -259,6 +265,7 @@
                     "type": "member",
                     "refType": "ref",
                     "name": "playerInstance",
+                    "reobfName": "playerEntity",
                     "parent": "cc.ig.gameMain",
                     "compiled": {
                         "type": "select",
@@ -278,6 +285,7 @@
                     "type": "member",
                     "refType": "ref",
                     "name": "getMapName",
+                    "reobfName": "mapName",
                     "parent": "cc.ig.gameMain",
                     "compiled": {
                         "type": "select",
@@ -320,6 +328,7 @@
                             "type": "member",
                             "refType": "ref",
                             "name": "getLoadingState",
+                            "reobfName": "currentLoadingResource",
                             "parent": "cc.ig.gameMain",
                             "compiled": {
                                 "type": "select",
@@ -339,6 +348,7 @@
                             "type": "member",
                             "refType": "var",
                             "name": "LoadMap",
+                            "reobfName": "preloadLevel",
                             "parent": "cc.ig.gameMain",
                             "compiled": {
                                 "pattern": "key.name",
@@ -357,7 +367,8 @@
                             "type": "member",
                             "refType": "raw",
                             "name": "CreateMap",
-                            "parent": "",
+                            "reobfName": "loadLevel",
+                            "parent": "cc.ig.gameMain",
                             "compiled": {
                                 "pattern": "key.name",
                                 "from": {
@@ -782,6 +793,7 @@
                             "type": "member",
                             "refType": "raw",
                             "name": "entityData",
+                            "reobfName": "coll",
                             "compiled": {
                                 "type": "select",
                                 "pattern": "body.3.expression.left.object.property.name",
@@ -800,6 +812,7 @@
                             "type": "member",
                             "refType": "raw",
                             "name": "entityPosition",
+                            "reobfName": "pos",
                             "compiled": {
                                 "type": "select",
                                 "pattern": "body.1.declarations.1.init.left.object.property.name",
@@ -818,6 +831,7 @@
                             "type": "member",
                             "refType": "raw",
                             "name": "entityKill",
+                            "reobfName": "kill",
                             "compiled": {
                                 "type": "select",
                                 "pattern": "body.0.expression.right.callee.property.name",
@@ -926,6 +940,7 @@
                             "type": "member",
                             "refType": "raw",
                             "name": "jump",
+                            "reobfName": "doJump",
                             "compiled": {
                                 "type": "select",
                                 "pattern": "body.1.expression.callee.property.name",
@@ -1227,6 +1242,53 @@
                                         }
                                     ]
                                 }
+                            }
+                        },
+                        {
+                            "type": "member",
+                            "refType": "raw",
+                            "name": "onPreUpdate",
+                            "parent": "",
+                            "compiled": {
+                                "pattern": "right.arguments.0.properties.2.key.name",
+                                "from": {
+                                    "type": "AssignmentExpression",
+                                    "values": [
+                                        {
+                                            "name": "left.object.name",
+                                            "value": "sc"
+                                        },
+                                        {
+                                            "name": "right.callee.object.object.name",
+                                            "value": "ig"
+                                        },
+                                        {
+                                            "name": "right.arguments.0.properties.0.value.body.body.0.expression.callee.object.type",
+                                            "value": "ThisExpression"
+                                        },
+                                        {
+                                            "name": "right.arguments.0.properties.0.value.body.body.0.expression.callee.property.name",
+                                            "value": "parent"
+                                        },
+                                        {
+                                            "name": "right.arguments.0.properties.0.value.body.body.0.expression.arguments.length",
+                                            "value": 1
+                                        },
+                                        {
+                                            "name": "right.arguments.0.properties.0.value.body.body.0.expression.arguments.0.value",
+                                            "value": "GlobalInput"
+                                        },
+                                        {
+                                            "name": "right.arguments.0.properties.1.value.raw",
+                                            "value": "5"
+                                        },
+                                        {
+                                            "name": "right.arguments.0.properties.2.value.type",
+                                            "value": "FunctionExpression"
+                                        }
+                                    ]
+                                },
+                                "type": "select"
                             }
                         }
                     ]
@@ -1734,6 +1796,93 @@
                             ]
                         }
                     }
+                },
+                {
+                    "type": "member",
+                    "refType": "raw",
+                    "name": "addGameAddon",
+                    "parent": "",
+                    "compiled": {
+                        "pattern": "callee.property.name",
+                        "from": {
+                            "type": "CallExpression",
+                            "values": [
+                                {
+                                    "name": "callee.object.name",
+                                    "value": "ig"
+                                },
+                                {
+                                    "name": "arguments.length",
+                                    "value": 1
+                                },
+                                {
+                                    "name": "arguments.0.type",
+                                    "value": "FunctionExpression"
+                                },
+                                {
+                                    "name": "arguments.0.body.type",
+                                    "value": "BlockStatement"
+                                },
+                                {
+                                    "name": "arguments.0.body.body.length",
+                                    "value": 1
+                                },
+                                {
+                                    "name": "arguments.0.body.body.0.type",
+                                    "value": "ReturnStatement"
+                                },
+                                {
+                                    "name": "arguments.0.body.body.0.argument.type",
+                                    "value": "MemberExpression"
+                                },
+                                {
+                                    "name": "arguments.0.body.body.0.argument.object.name",
+                                    "value": "sc"
+                                },
+                                {
+                                    "name": "arguments.0.body.body.0.argument.property.name",
+                                    "value": "sc.fontsystem",
+                                    "type": "dynamic"
+                                }
+                            ]
+                        },
+                        "type": "select"
+                    }
+                },
+                {
+                    "type": "member",
+                    "refType": "raw",
+                    "name": "GameAddon",
+                    "parent": "",
+                    "compiled": {
+                        "pattern": "right.callee.object.property.name",
+                        "from": {
+                            "type": "AssignmentExpression",
+                            "values": [
+                                {
+                                    "name": "left.object.name",
+                                    "value": "sc"
+                                },
+                                {
+                                    "name": "right.callee.object.object.name",
+                                    "value": "ig"
+                                },
+                                {
+                                    "name": "right.arguments.length",
+                                    "value": 1
+                                },
+                                {
+                                    "name": "right.arguments.0.properties.0.value.body.body.0.expression.arguments.length",
+                                    "value": 1
+                                },
+                                {
+                                    "name": "right.arguments.0.properties.0.value.body.body.0.expression.arguments.0.value",
+                                    "value": "GlobalInput"
+                                }
+                            ]
+                        },
+                        "type": "select"
+                    }
                 }
             ]
         },
@@ -1828,6 +1977,7 @@
                     "type": "member",
                     "refType": "var",
                     "name": "playerModelInstance",
+                    "reobfName": "player",
                     "parent": "sc",
                     "compiled": {
                         "type": "select",
@@ -2154,6 +2304,38 @@
                                         }
                                     ]
                                 }
+                            }
+                        },
+                        {
+                            "type": "member",
+                            "refType": "raw",
+                            "name": "jumping",
+                            "parent": "",
+                            "compiled": {
+                                "pattern": "body.1.consequent.expression.left.property.name",
+                                "from": {
+                                    "type": "BlockStatement",
+                                    "values": [
+                                        {
+                                            "name": "body.length",
+                                            "value": "2"
+                                        },
+                                        {
+                                            "name": "body.0.expression.callee.property.name",
+                                            "value": "cc.ig.varNames.jump",
+                                            "type": "dynamic"
+                                        },
+                                        {
+                                            "name": "body.1.test.argument.object.type",
+                                            "value": "ThisExpression"
+                                        },
+                                        {
+                                            "name": "body.1.consequent.expression.type",
+                                            "value": "AssignmentExpression"
+                                        }
+                                    ]
+                                },
+                                "type": "select"
                             }
                         }
                     ]
@@ -2498,6 +2680,29 @@
                                 }
                             ]
                         }
+                    }
+                },
+                {
+                    "type": "member",
+                    "refType": "raw",
+                    "name": "commonEvents",
+                    "parent": "",
+                    "compiled": {
+                        "pattern": "callee.object.property.name",
+                        "from": {
+                            "type": "CallExpression",
+                            "values": [
+                                {
+                                    "name": "callee.object.object.name",
+                                    "value": "sc"
+                                },
+                                {
+                                    "name": "arguments.0.value",
+                                    "value": "MAP_ENTERED"
+                                }
+                            ]
+                        },
+                        "type": "select"
                     }
                 }
             ]

--- a/ccloader/data/definitions.db
+++ b/ccloader/data/definitions.db
@@ -1290,6 +1290,106 @@
                                 },
                                 "type": "select"
                             }
+                        },
+                        {
+                            "type": "member",
+                            "refType": "raw",
+                            "name": "onStorageSave",
+                            "parent": "",
+                            "compiled": {
+                                "pattern": "body.4.body.expression.right.callee.property.name",
+                                "from": {
+                                    "type": "BlockStatement",
+                                    "values": [
+                                        {
+                                            "name": "body.1.expression.left.property.name",
+                                            "value": "map"
+                                        },
+                                        {
+                                            "name": "body.2.expression.left.property.name",
+                                            "value": "vars"
+                                        },
+                                        {
+                                            "name": "body.3.expression.left.property.name",
+                                            "value": "position"
+                                        },
+                                        {
+                                            "name": "body.4.body.expression.right.callee.object.object.object.type",
+                                            "value": "ThisExpression"
+                                        }
+                                    ]
+                                },
+                                "type": "select"
+                            }
+                        },
+                        {
+                            "type": "member",
+                            "refType": "raw",
+                            "name": "onStoragePreLoad",
+                            "parent": "",
+                            "compiled": {
+                                "pattern": "key.name",
+                                "from": {
+                                    "type": "Property",
+                                    "values": [
+                                        {
+                                            "name": "value.body.body.0.expression.right.property.name",
+                                            "value": "bgm"
+                                        }
+                                    ]
+                                },
+                                "type": "select"
+                            }
+                        },
+                        {
+                            "type": "member",
+                            "refType": "raw",
+                            "name": "onStoragePostLoad",
+                            "parent": "",
+                            "compiled": {
+                                "pattern": "key.name",
+                                "from": {
+                                    "type": "Property",
+                                    "values": [
+                                        {
+                                            "name": "value.body.body.0.test.right.property.name",
+                                            "value": "bgm"
+                                        }
+                                    ]
+                                },
+                                "type": "select"
+                            }
+                        },
+                        {
+                            "type": "member",
+                            "refType": "raw",
+                            "name": "register",
+                            "parent": "",
+                            "compiled": {
+                                "pattern": "body.1.expression.callee.property.name",
+                                "from": {
+                                    "type": "BlockStatement",
+                                    "values": [
+                                        {
+                                            "name": "body.0.expression.callee.property.name",
+                                            "value": "parent"
+                                        },
+                                        {
+                                            "name": "body.0.expression.arguments.0.value",
+                                            "value": "BGM"
+                                        },
+                                        {
+                                            "name": "body.1.expression.callee.object.object.name",
+                                            "value": "ig"
+                                        },
+                                        {
+                                            "name": "body.1.expression.arguments.0.type",
+                                            "value": "ThisExpression"
+                                        }
+                                    ]
+                                },
+                                "type": "select"
+                            }
                         }
                     ]
                 },
@@ -2317,10 +2417,6 @@
                                     "type": "BlockStatement",
                                     "values": [
                                         {
-                                            "name": "body.length",
-                                            "value": "2"
-                                        },
-                                        {
                                             "name": "body.0.expression.callee.property.name",
                                             "value": "cc.ig.varNames.jump",
                                             "type": "dynamic"
@@ -2699,6 +2795,37 @@
                                 {
                                     "name": "arguments.0.value",
                                     "value": "MAP_ENTERED"
+                                }
+                            ]
+                        },
+                        "type": "select"
+                    }
+                },
+                {
+                    "type": "member",
+                    "refType": "raw",
+                    "name": "version",
+                    "parent": "",
+                    "compiled": {
+                        "pattern": "arguments.0.body.body.1.expression.left.property.name",
+                        "from": {
+                            "type": "CallExpression",
+                            "values": [
+                                {
+                                    "name": "callee.object.callee.object.arguments.0.value",
+                                    "value": "game.feature.version.version"
+                                },
+                                {
+                                    "name": "arguments.0.body.body.1.expression.left.object.name",
+                                    "value": "sc"
+                                },
+                                {
+                                    "name": "arguments.0.body.body.1.expression.right.callee.object.name",
+                                    "value": "sc"
+                                },
+                                {
+                                    "name": "arguments.0.body.body.1.expression.right.arguments.length",
+                                    "value": 0
                                 }
                             ]
                         },

--- a/ccloader/index.html
+++ b/ccloader/index.html
@@ -2,10 +2,13 @@
 	<head>
 		<title>CrossCode - CCLoader</title>
 		<link rel="stylesheet" href="index.css">
+		<script type="text/javascript" src="js/2.5.3-crypto-md5.js"></script>
+		<script type="text/javascript" src="js/nodemodules.js"></script>
 		<script type="text/javascript" src="js/normalize.js"></script>
 		<script type="text/javascript" src="js/filemanager.js"></script>
 		<script type="text/javascript" src="js/db.js"></script>
 		<script type="text/javascript" src="js/acorn.js"></script>
+		<script type="text/javascript" src="js/kireobf.js"></script>
 		<script type="text/javascript" src="js/mod.js"></script>
 		<script type="text/javascript" src="js/ccloader.js"></script>
 		<script type="text/javascript" src="js/main.js"></script>

--- a/ccloader/js/acorn.js
+++ b/ccloader/js/acorn.js
@@ -209,17 +209,19 @@ function Acorn(){
 	
 	function _buildMember(db, member, value){
 		//var value = _getVar(member.compiled);
-		
+		// REGARDING REOBF NAMES! These absolutely should not be messed with.
+		// Setting them to "getMapName" when the actual true name is "mapName" but this happens to be structured as an accessor,
+		//  is the kind of thing NOT to do if you don't want to completely ruin the point of the reobf mode.
 		switch(member.refType){
 			case "raw":
-				db.addRawMember(member.name, value);
+				db.addRawMember(member.name, member.reobfName || member.name, value);
 				break;
 			case "ref":
-				db.addMemberReference(member.name, member.parent, value);
+				db.addMemberReference(member.name, member.reobfName || member.name, member.parent, value);
 				break;
 			case "var":
 			default:
-				db.addMember(member.name, member.parent, value);
+				db.addMember(member.name, member.reobfName || member.name, member.parent, value);
 				break;
 		}
 	}
@@ -253,6 +255,8 @@ function Acorn(){
 							result = result.members[i];
 							break;
 						}else{
+							if (!result.members[i].compiledName)
+								console.warn("Couldn't lookup dynamic '" + pair.value + "'");
 							return result.members[i].compiledName;
 						}
 					}

--- a/ccloader/js/acorn.js
+++ b/ccloader/js/acorn.js
@@ -1,6 +1,5 @@
 function Acorn(){
-	var ac, walker,
-	    acornLoaded = false, 
+	var acornLoaded = false, 
 	    walkerLoaded = false;
 	
 	var tree = undefined;
@@ -8,30 +7,20 @@ function Acorn(){
 	var definitions = [];
 	
 	this.initialize = function(cb){
-		if(window.require){
-		ac = require("acorn");
-		walker = require("acorn/dist/walk");
-		acornLoaded = true;
-		walkerLoaded = true;
-		cb();
-	}else{
-		_loadScript("/node_modules/acorn/dist/acorn.js", function(){
-			ac = window.acorn;
+		nodemodules.on("acorn", function () {
 			acornLoaded = true;
 			if(walkerLoaded)
 				cb();
-		})
-		_loadScript("/node_modules/acorn/dist/walk.js", function(){
-			walker = window.acorn.walk;
+		});
+		nodemodules.on("acorn/dist/walk", function () {
 			walkerLoaded = true;
 			if(acornLoaded)
 				cb();
-		})
+		});
 	}
-	
-	}
+
 	this.parse = function(jscode){
-		tree = ac.parse(jscode, {onToken: function(){}});
+		tree = acorn.parse(jscode, {onToken: function(){}});
 		
 		//Fancy new and fast searching algorithm
 		/*setTimeout(function(){
@@ -43,7 +32,7 @@ function Acorn(){
 			var single = false;	
 
 
-			walker.fullAncestor(tree, function(node, state, ancestor, type){
+			acorn.walk.fullAncestor(tree, function(node, state, ancestor, type){
 				if(single && results.length)
 					return;
 				
@@ -121,7 +110,7 @@ function Acorn(){
 			var i = 0, steps = 14, depth = 20;
 			var pattern = "CURRENT_STATE";
 			var searched = "de";
-			var result = walker.findNodeAt(tree, null, null, function(nodeType, node){
+			var result = acorn.walk.findNodeAt(tree, null, null, function(nodeType, node){
 					function search(n, layers){
 						if(layers <= 0)
 							if(n === pattern){
@@ -181,7 +170,7 @@ function Acorn(){
 		while(definitions.length > 0) {
 			var start = definitions.length;
 			
-			walker.findNodeAt(tree, undefined, undefined, function(nodeType, node){
+			acorn.walk.findNodeAt(tree, undefined, undefined, function(nodeType, node){
 				for(var i = 0; i < definitions.length; i++){
 					var value = _getSelectVar(definitions[i].member.compiled, nodeType, node);
 					if(value !== undefined) {
@@ -284,12 +273,5 @@ function Acorn(){
 		}
 		
 		return result;
-	}
-	function _loadScript(url, callback){
-		var script = document.createElement("script");
-		document.body.appendChild(script);
-		script.onload = callback;
-		script.type = "text/javascript";
-		script.src = url;
 	}
 }

--- a/ccloader/js/ccloader.js
+++ b/ccloader/js/ccloader.js
@@ -32,11 +32,15 @@ function ModLoader(){
 		});
 	}
 	this.startGame = function(){
-		// Pull the handbrake
+		// Pull the handbrake.
+		// To explain what's going on here:
+		// We need to stop the game getting too far along if we want to, say, hook the DoThing function of all instances of class ABC from game start.
+		// This means we need to stop the game loading, and thankfully their use of window["process"].once aids this.
 		windowProcessOnce = window.process.once;
 		window.process.once = null;
 		this.status.innerHTML = "Initializing Game";
 		this.frame.onload = _onGameWindowReady.bind(this);
+		console.log("NOTE! The window.process.once-related exception in node-webkit.html you are about to see was filmed in a studio environment. Do not try at home.");
 		this.frame.src = window.require ? '../assets/node-webkit.html' : '/assets/node-webkit.html';
 	}
 	this.reloadTables = function(){

--- a/ccloader/js/ccloader.js
+++ b/ccloader/js/ccloader.js
@@ -158,9 +158,8 @@ function ModLoader(){
 				this.frame.contentWindow.activeMods.push(this.mods[i]);
 
 				(function(mod){
-					mod.load(function(){
+					mod.execute(_instance, function(){
 						_instance.modsLoaded++;
-						mod.executeTable(_instance);
 					});
 				})(this.mods[i]);
 			} else {

--- a/ccloader/js/kireobf.js
+++ b/ccloader/js/kireobf.js
@@ -1,0 +1,47 @@
+// Reobfuscator
+// NOTE! Doesn't support GCall transform, so needs minor expansion to deobfuscate game
+
+var kireobf = function(code, remapId) {
+	var propKey = function (tkns, i) {
+		if (i > 1) {
+			if (tkns[i - 2] == ".") {
+				return true;
+			} else if (i < tkns.length - 2) {
+				if (tkns[i + 2] == ":") {
+					if (tkns[i - 2] == ",")
+						return true;
+					if (tkns[i - 2] == "{")
+						return true;
+				}
+			}
+		}
+		return false;
+	};
+
+	// We don't need to parse it (inefficient, especially to reverse the process), just tokenize it.
+	var parser = acorn.tokenizer(code);
+	var lastIndex = 0;
+	var components = [];
+	while (true) {
+		parser.nextToken();
+		if (parser.type == acorn.tokTypes.eof)
+			break;
+		// Whitespace is interleaved precisely
+		components.push(code.substring(lastIndex, parser.start));
+		components.push(code.substring(parser.start, parser.end));
+		lastIndex = parser.end;
+	}
+	components.push(code.substring(lastIndex));
+	// Just iterates over actual tokens
+	for (var i = 1; i < components.length; i += 2) {
+		if (propKey(components, i)) {
+			var remapped = remapId(components[i]);
+			if (remapped != null)
+				components[i] = " " + remapped + " /* " + components[i] + " */ ";
+		}
+	}
+	code = "";
+	for (var i = 0; i < components.length; i++)
+		code += components[i];
+	return code;
+};

--- a/ccloader/js/mod.js
+++ b/ccloader/js/mod.js
@@ -45,6 +45,11 @@ function Mod(file){
 		});
 	}
 
+	// postExecModules / gameLoaded
+	this.getExecutionTime = function(){
+		return manifest.executionTime || "gameLoaded";
+	}
+
 	// Add definitions, run the script, after that's run call the callback function.
 	this.execute = function(ccloader, cb){
 		if(!loaded)
@@ -161,12 +166,12 @@ function Mod(file){
 		if(!loaded)
 			return false;
 		
-		var globals = frame.contentWindow.cc.ig.storage[frame.contentWindow.cc.ig.varNames.storageGlobals];
+		var globals = frame.contentWindow.localStorage;
 		
-		if(!globals || !globals.options)
+		if(!globals)
 			return true;
 		
-		return globals.options['modEnabled-' + manifest.name.toLowerCase()] !== false;
+		return globals['options.modEnabled-' + manifest.name.toLowerCase()] !== false;
 	}
 	
 	function _getModNameFromFile(){

--- a/ccloader/js/mod.js
+++ b/ccloader/js/mod.js
@@ -44,14 +44,28 @@ function Mod(file){
 				onload();
 		});
 	}
-	this.load = function(cb){
+
+	// Add definitions, run the script, after that's run call the callback function.
+	this.execute = function(ccloader, cb){
 		if(!loaded)
 			return;
+
+		if(table)
+			table.executeDb(ccloader.frame.contentWindow, ccloader.frame.contentWindow);
 
 		if(!manifest.main)
 			return cb();
 
-		filemanager.loadMod(manifest.main, cb);
+		if (manifest.reobf) {
+			filemanager.loadModTransformed(manifest.main, (function (code) {
+				return kireobf(code, (function (id) {
+					// I'm unsure if modloaderdbs get merged correctly. Also, inefficient to walk the tree for no reason
+					return ccloader.frame.contentWindow.modloadermap.get(id);
+				}).bind(this));
+			}).bind(this), cb);
+		} else {
+			filemanager.loadMod(manifest.main, cb);
+		}
 	}
 	this.onload = function(cb){
 		loading = true;
@@ -135,12 +149,6 @@ function Mod(file){
 			
 			cb();
 		});
-	}
-	this.executeTable = function(ccloader){
-		if(!loaded || !table)
-			return;
-
-		table.executeDb(ccloader.frame.contentWindow, ccloader.frame.contentWindow);
 	}
 
 	this.isLoading = function(){

--- a/ccloader/js/nodemodules.js
+++ b/ccloader/js/nodemodules.js
@@ -1,0 +1,47 @@
+// Load node modules that we're particularly interested in.
+var nodemodules;
+(function () {
+	// Modules are loaded in order if require is available.
+	// A module entry is: JS, onNodeLoad, onJSLoad, loadCallbacks
+	var modules = new Map();
+	var moduleOrder = ["acorn", "acorn/dist/walk"];
+	modules.set("acorn", [
+		"/node_modules/acorn/dist/acorn.js", function (n) { window.acorn = n; }, function () {}, []
+	]);
+	modules.set("acorn/dist/walk", [
+		"/node_modules/acorn/dist/walk.js", function (n) { window.acorn.walk = n; }, function () {}, []
+	]);
+	var loadedModules = new Set();
+	nodemodules = {
+		on: function (name, func) {
+			if (loadedModules.has(name)) {
+				func();
+			} else {
+				modules.get(name)[3].push(func);
+			}
+		}
+	};
+	function _loadScript(url, callback){
+		var script = document.createElement("script");
+		document.body.appendChild(script);
+		script.onload = callback;
+		script.type = "text/javascript";
+		script.src = url;
+	}
+	for (var i = 0; i < moduleOrder.length; i++) {
+		const moduleId = moduleOrder[i];
+		const module = modules.get(moduleId);
+		if (window.require) {
+			loadedModules.add(moduleOrder[i]);
+			module[1](require(moduleOrder[i]));
+		} else {
+			_loadScript(module[0], function () {
+				loadedModules.add(moduleId);
+				module[2]();
+				for (var j = 0; j < module[3].length; j++)
+					module[3][j]();
+			});
+		}
+	}
+})();
+


### PR DESCRIPTION
Firstly, about the loader branding mod:
I needed a test mod that had a reason to exist, and this is what I came up with.
It does a slight hook to `sc.version` to add a `W/MODS` banner, then creates a GameAddon to inject a key into savefiles for the purpose of alerting devs who might well receive savefiles from a modified version of the game. No further information is provided other than a clear indicator that the game has been modified. Admittedly this is easy to turn off, but at that point one could just remove whatever code we'd use to brand the savefiles.

Secondly, extension notes:
1. This makes an extension to the mod format in the form of the `executionTime` key, which specifies when the mod is to be executed. Valid values so far are the default `gameLoaded` and the much earlier `postExecModules` (which occurs after all game classes and some singletons are loaded, but before the game's Loader is created and before addGameAddon callbacks, which may have several uses in regards to anything that messes with the Impact resource system, or that uses GameAddons as a core component.)
2. This makes an extension to the definitions format in the form of the `reobfName` key, which is used because certain `definitions.db` keys are clearly meant to be reflections of the *modding API* and not, in fact, CrossCode itself. `getMapName` comes to mind. This said, it should also be used if anyone spots any keys that don't match 0.7.0 game.min.js. Thus, reobfName exists to ensure the reobfuscation mapping is kept correct.
3. I have a version of the definitions editor fully compatible with this version (including bringing it up to date with support for `dynamic` values entries, and making a different mechanism for creating selectors), and I gave 2767mr the patches for it.

Thirdly, why reobfuscated mods (or "why is this PR not pointless bloat"):
CrossCode's, well, code, is rather extendable by nature. Between GameAddons, the way every class can be extended (and replaced, though this is something only mods need to do), and the various systems that will call functions on your own objects if you "ask nicely enough" (`ig.storage.register`), it seems to me as if mods would be simpler if we were working with these systems rather than actively try to avoid them, hook them, and replace functions all the time to get at them.

I'm not saying replacing functions is unnecessary. I'm saying that if a better way is available it's good to take it.

The only limiter that remains is what people are willing to put in the definitions file.

Fourth, please be noted that this commit does mess around with CCLoader's loading a bit because 1. The reobfuscator needs access to Acorn, 2. The reobfuscator needs early access to tables because 3. Early-loaded mods change the loading system around a bit.

Regarding how node modules are loaded:
Future node modules should be loaded via `nodemodules.js`, and if some sort of Node emulation environment needs to be created, that's where to go.