### PR TITLE
filemanager: Fix browser issue with xhr.

### DIFF
--- a/ccloader/js/filemanager.js
+++ b/ccloader/js/filemanager.js
@@ -96,7 +96,7 @@ export class Filemanager {
 				req.open('GET', '/' + resource, false);
 				req.send(null);
 
-				if(req.status === 200) {
+				if(req.readyState === req.DONE && req.status === 200) {
 					return req.responseText;
 				} else {
 					return undefined;
@@ -128,7 +128,7 @@ export class Filemanager {
 
 				req.onerror = err => reject(err);
 				req.onreadystatechange = () => {
-					if (req.status === 200) {
+					if (req.readyState === req.DONE && req.status === 200) {
 						resolve(req.responseText);
 					}
 				};


### PR DESCRIPTION
The onreadystatechange callback only checked that the status is 200, but
didn't check readyState.  As a result, if readyState is HEADER_RECEIVED,
then status is already 200 but responseText is empty and we would pass
it around.