### PR TITLE
mod: Add ccmodDependencies support

### DIFF
--- a/assets/mods/ccloader-version-display/package.json
+++ b/assets/mods/ccloader-version-display/package.json
@@ -1,8 +1,8 @@
 {
 	"name" : "CCLoader display version",
 	"main" : "mod.js",
-	"version" : "1.1.0",
-	"dependencies": {
+	"version" : "1.1.1",
+	"ccmodDependencies": {
 		"crosscode": "^1.1.0"
 	}
 }

--- a/assets/mods/simplify/package.json
+++ b/assets/mods/simplify/package.json
@@ -3,9 +3,9 @@
 	"main": "mod.js",
 	"preload": "preload.js",
 	"postload": "postload.js",
-	"version": "2.3.2",
-	"dependencies": {
-		"ccloader": "^2.10.0",
+	"version": "2.3.3",
+	"ccmodDependencies": {
+		"ccloader": "^2.11.0",
 		"crosscode": "^1.0.0"
 	}
 }

--- a/ccloader/js/ccloader.js
+++ b/ccloader/js/ccloader.js
@@ -4,7 +4,7 @@ import { Mod } from './mod.js';
 import { UI } from './ui.js';
 import { Loader } from './loader.js';
 
-const CCLOADER_VERSION = '2.10.4';
+const CCLOADER_VERSION = '2.11.0';
 
 export class ModLoader {
 	constructor() {

--- a/ccloader/js/mod.js
+++ b/ccloader/js/mod.js
@@ -20,7 +20,7 @@ export class Mod {
 		}
 		
 		try {
-			/** @type {{name: string, version?: string, description?: string, main?: string, preload?: string, postload?: string, table?: string, assets: string[], dependencies: {[key: string]: string}}} */
+			/** @type {{name: string, version?: string, description?: string, main?: string, preload?: string, postload?: string, table?: string, assets: string[], ccmodDependencies: {[key: string]: string}}} */
 			this.manifest = JSON.parse(data);
 			if(!this.manifest)
 				return;

--- a/ccloader/js/mod.js
+++ b/ccloader/js/mod.js
@@ -33,6 +33,10 @@ export class Mod {
 		this.manifest.preload = this._normalizeScript(file, this.manifest.preload);
 		this.manifest.postload = this._normalizeScript(file, this.manifest.postload);
 		
+		if(!this.manifest.ccmodDependencies) {
+			this.manifest.ccmodDependencies = this.manifest.dependencies;
+		}
+		
 		if(this.manifest.table){
 			if(!this._isPathAbsolute(this.manifest.table)) {
 				this.manifest.table = this._getBaseName(file) + '/' + this.manifest.table;
@@ -99,7 +103,7 @@ export class Mod {
 	get dependencies(){
 		if(!this.loaded)
 			return undefined;
-		return this.manifest.dependencies;
+		return this.manifest.ccmodDependencies;
 	}
 	get version(){
 		if(!this.loaded)


### PR DESCRIPTION
Properly supports the move to "ccmodDependencies" to avoid conflict with Node, as defined in the Standardized Mods specification.
Certain to not break compatibility, required for conformance tests & other standardized-mods on the new system to operate properly outside of coincidental ordering.
