### PR TITLE
Handle jQuery.ajax errors properly.

### DIFF
--- a/assets/mods/simplify/package.json
+++ b/assets/mods/simplify/package.json
@@ -5,7 +5,7 @@
 	"postload": "postload.js",
 	"plugin": "plugin.js",
 	"hidden": true,
-	"version": "2.6.0",
+	"version": "2.6.1",
 	"ccmodDependencies": {
 		"ccloader": "^2.11.0",
 		"crosscode": "^1.0.0"

--- a/assets/mods/simplify/postloadModule.js
+++ b/assets/mods/simplify/postloadModule.js
@@ -236,7 +236,13 @@ import * as patchSteps from './lib/patch-steps-es6.js';
 					// Run request pre handlers
 					this._callHandlers(settings, true);
 
-					const successArgs = await this._handleAjaxPatching(originalUrl, this._waitForAjax(settings));
+					var successArgs;
+					try {
+						successArgs = await this._handleAjaxPatching(originalUrl, this._waitForAjax(settings));
+					} catch (errorArgs) {
+						settings.error.apply(settings.context, errorArgs);
+						return;
+					}
 
 					// Done, run final handlers
 					this._callHandlers(settings, false);
@@ -275,9 +281,9 @@ import * as patchSteps from './lib/patch-steps-es6.js';
 					this._restoreSettings(settings, success, error);
 					resolve(sArgs);
 				};
-				settings.error = (_, text) => {
+				settings.error = (...eArgs) => {
 					this._restoreSettings(settings, success, error);
-					reject(text);
+					reject(eArgs);
 				};
 			});
 		}

--- a/assets/mods/simplify/postloadModule.js
+++ b/assets/mods/simplify/postloadModule.js
@@ -236,11 +236,11 @@ import * as patchSteps from './lib/patch-steps-es6.js';
 					// Run request pre handlers
 					this._callHandlers(settings, true);
 
-					var successArgs;
+					let successArgs;
 					try {
 						successArgs = await this._handleAjaxPatching(originalUrl, this._waitForAjax(settings));
-					} catch (errorArgs) {
-						settings.error.apply(settings.context, errorArgs);
+					} catch (e) {
+						settings.error.apply(settings.context, e);
 						return;
 					}
 
@@ -281,9 +281,9 @@ import * as patchSteps from './lib/patch-steps-es6.js';
 					this._restoreSettings(settings, success, error);
 					resolve(sArgs);
 				};
-				settings.error = (...eArgs) => {
+				settings.error = (...err) => {
 					this._restoreSettings(settings, success, error);
-					reject(eArgs);
+					reject(err);
 				};
 			});
 		}
@@ -322,11 +322,33 @@ import * as patchSteps from './lib/patch-steps-es6.js';
 				promises.push(this.loadJSON(patch.path));
 
 			// Done making the parallel requests
-			const values = await Promise.all(promises);
-			const successArgs = values[0];
-			for (let i = 0; i < patches.length; i++)
+			const values = await this._awaitAll(promises);
+			if (values[0].status !== 'resolved') {
+				throw values[0].value;
+			}
+
+			const successArgs = values[0].value;
+			for (let i = 0; i < patches.length; i++) {
+				if (values[i + 1].status !== 'resolved') {
+					console.error(`Could not load patch '${patches[i].path}' for '${url}': `, values[i + 1].value);
+					continue;
+				}
+
 				await this._applyPatch(successArgs[0], values[i + 1], patches[i].mod.baseDirectory);
+			}
 			return successArgs;
+		}
+
+		/**
+		 * Awaits all Promises given but does not fail on rejects.
+		 * @param {Promise<any>[]} promises
+		 * @returns {Promise<{status: 'resolved' | 'rejected', value: any}[]>}
+		 */
+		_awaitAll(promises) {
+			return Promise.all(promises.map(p => p
+				.then(value => ({status: 'resolved', value: value}))
+				.catch(err => ({status: 'rejected', value: err}))
+			));
 		}
 	
 		_hookHttpRequest() {


### PR DESCRIPTION
Since the patch step implementation, jQuery's 'error' callback is
wrapped in a promise without being handled properly by the caller,
so the true error callback is never called.

As a result, any failure to load anything prevents the game from
launching, even if the game is perfectly able to cope with the
failure.

(note: this does not call the handlers on errors, but i don't know what those handlers are for)