### PR TITLE
Complain with a better warning when a mod misses some dependencies.

### DIFF
--- a/ccloader/js/ccloader.js
+++ b/ccloader/js/ccloader.js
@@ -121,7 +121,7 @@ export class ModLoader {
 		}
 
 		for (const mod of this.mods.filter(m => m.isEnabled)) {
-			this._printMissingDependencies(mod, mods);
+			this._printMissingDependencies(mod, this.mods);
 		}
 
 		for (const mod of this.mods) {
@@ -201,14 +201,14 @@ export class ModLoader {
 				}
 			}
 
-			if (depVersion === null) {
-				result[depName] = `${depDesc} is missing. Please install it.`;
+			if (!enabled) {
+				result[depName] = `${depDesc} is disabled`;
+			} else if (depVersion === null) {
+				result[depName] = `${depDesc} is missing`;
 			} else if (semver.valid(depVersion) === null) {
 				result[depName] = `${depDesc}'s version "${depVersion}" has a syntax error`;
 			} else if (!semver.satisfies(depVersion, depRange)) {
 				result[depName] = `requires ${depDesc} version ${depRange} but version ${depVersion} present`;
-			} else if (!enabled) {
-				result[depName] = `${depDesc} is disabled`;
 			}
 		}
 

--- a/ccloader/js/ccloader.js
+++ b/ccloader/js/ccloader.js
@@ -120,11 +120,10 @@ export class ModLoader {
 			}
 		}
 
-		for (const mod of this.mods) {
-			if (!mod.isEnabled)
-				continue;
-			this._complainMissingDependencies(mod, mods);
+		for (const mod of this.mods.filter(m => m.isEnabled)) {
+			this._printMissingDependencies(mod, mods);
 		}
+
 		for (const mod of this.mods) {
 			mod.disabled = true;
 			mods.push(mod);
@@ -133,14 +132,17 @@ export class ModLoader {
 		this.mods = mods;
 	}
 
-	/*
+	/**
 	 * Complain that dependencies are not satisfied.
+	 * @param {Mod} mod
+	 * @param {Mod[]} mods
 	 */
-	_complainMissingDependencies(mod, mods) {
-		const bad_deps = this._unmetModDependencies(mod, mods);
+	_printMissingDependencies(mod, mods) {
+		const badDeps = this._unmetModDependencies(mod, mods);
 		const prefix = `Could not load mod ${mod.name}: `;
-		for (const depName in bad_deps)
-			console.warn(prefix + bad_deps[depName]);
+		for (const depName in badDeps) {
+			console.warn(prefix + badDeps[depName]);
+		}
 	}
 
 	/**
@@ -149,15 +151,16 @@ export class ModLoader {
 	 * @param {Mod[]} mods
 	 */
 	_canLoad(mod, mods) {
-		if (!mod.isEnabled)
+		if (!mod.isEnabled) {
 			return false;
+		}
 		return this._unmetModDependencies(mod, mods) === null;
 	}
 
 	/**
-	 * @param {Mod} check dependencies of this mod.
+	 * @param {Mod} mod check dependencies of this mod.
 	 * @param {Mod[]} mods list of available mods.
-	 * @return {Object|null} Object whose keys are dependencies that cannot
+	 * @return {{[name: string]: string}|null} Object whose keys are dependencies that cannot
 	 * be used and values are error messages explaining why.
 	 */
 	_unmetModDependencies(mod, mods) {
@@ -165,20 +168,19 @@ export class ModLoader {
 		if(!deps) {
 			return null;
 		}
-		const ret = {};
 
+		/** @type {{[name: string]: string}} */
+		const result = {};
 		for (const depName in deps) {
 			if(!Object.prototype.hasOwnProperty.call(deps, depName))
 				continue;
 
 			const depRange = semver.validRange(deps[depName]);
 			if(!depRange) {
-				ret[depName] = (
-					'Syntax error in version range '
-					+`"${deps[depName]}" for dependency `
-					+ depName);
+				result[depName] = `Syntax error in version range "${deps[depName]}" for dependency ${depName}`;
 				continue;
 			}
+
 			let depVersion = null;
 			let enabled = true;
 			let depDesc = depName;
@@ -198,25 +200,22 @@ export class ModLoader {
 					enabled = mod.isEnabled;
 				}
 			}
-			if (depVersion === null)
-				ret[depName] = (
-					`${depDesc} is missing. `
-					+ 'Please install it.');
-			else if (semver.valid(depVersion) === null)
-				ret[depName] = (
-					`${depDesc}'s version "${depVersion}" `
-					+ 'has a syntax error');
-			else if (!semver.satisfies(depVersion, depRange))
-				ret[depName] = (
-					`requires ${depDesc} version `
-					+ `${depRange} but version `
-					+ ` ${depVersion} present`);
-			else if (!enabled)
-				ret[depName] = `${depDesc} is disabled`;
+
+			if (depVersion === null) {
+				result[depName] = `${depDesc} is missing. Please install it.`;
+			} else if (semver.valid(depVersion) === null) {
+				result[depName] = `${depDesc}'s version "${depVersion}" has a syntax error`;
+			} else if (!semver.satisfies(depVersion, depRange)) {
+				result[depName] = `requires ${depDesc} version ${depRange} but version ${depVersion} present`;
+			} else if (!enabled) {
+				result[depName] = `${depDesc} is disabled`;
+			}
 		}
-		if (Object.keys(ret).length === 0)
+
+		if (Object.keys(result).length === 0) {
 			return null;
-		return ret;
+		}
+		return result;
 	}
 
 	/**

--- a/ccloader/js/ccloader.js
+++ b/ccloader/js/ccloader.js
@@ -191,7 +191,7 @@ export class ModLoader {
 				depVersion = this.ccVersion;
 				break;
 			default:
-				depDesc + 'mod ' + depDesc;
+				depDesc = 'mod ' + depDesc;
 				mod = mods.find(m => m.name === depName);
 				if (mod) {
 					depVersion = mod.version;

--- a/ccloader/js/ccloader.js
+++ b/ccloader/js/ccloader.js
@@ -6,7 +6,7 @@ import { Loader } from './loader.js';
 import { Plugin } from './plugin.js';
 import { Greenworks } from './greenworks.js';
 
-const CCLOADER_VERSION = '2.15.1';
+const CCLOADER_VERSION = '2.15.2';
 
 export class ModLoader {
 	constructor() {


### PR DESCRIPTION
Add functions to get a better error message when a mod cannot be loaded
because of missing dependencies, wrong dependency version or
crosscode/ccloader version.

Log them to the console for now. This already help with #53.