### PR TITLE
Add an environment variable for overriding the main URL

### DIFF
--- a/ccloader/index.html
+++ b/ccloader/index.html
@@ -1,13 +1,5 @@
 <html>
 	<head>
-		<script type="text/javascript">
-			(function(){
-				if (window.process) {
-					var envVar = process.env.CCLOADER_OVERRIDE_MAIN_URL;
-					if (envVar) window.location.replace(envVar);
-				}
-			})();
-		</script>
 		<title>CrossCode - CCLoader</title>
 		<link rel="stylesheet" href="index.css">
 		<script type="text/javascript">
@@ -19,7 +11,6 @@
 		</script>
 		<script type="text/javascript" src="js/lib/2.5.3-crypto-md5.js"></script>
 		<script type="text/javascript" src="js/lib/semver.browser.js"></script>
-		<script type="text/javascript" src="js/normalize.js"></script>
 		<script type="module" src="js/main.js"></script>
 	</head>
 		<iframe id="frame"></iframe>

--- a/ccloader/index.html
+++ b/ccloader/index.html
@@ -1,9 +1,22 @@
 <html>
 	<head>
-		<script>!function(){var e="CCLOADER_OVERRIDE_MAIN_URL";window.process&&process.env&&process.env[e]&&window.location.replace(process.env[e])}();</script>
+		<script type="text/javascript">
+			(function(){
+				if (window.process) {
+					var envVar = process.env.CCLOADER_OVERRIDE_MAIN_URL;
+					if (envVar) window.location.replace(envVar);
+				}
+			})();
+		</script>
 		<title>CrossCode - CCLoader</title>
 		<link rel="stylesheet" href="index.css">
-		<script type="text/javascript">try{eval('() => {const x=0}')}catch(e){alert('Please use the "nwjs_new" version of CrossCode to use CCLoader!')}</script>
+		<script type="text/javascript">
+			try {
+				eval('()=>{const x=0}');
+			} catch (e) {
+				alert('Please use the "nwjs_new" version of CrossCode to use CCLoader!')
+			}
+		</script>
 		<script type="text/javascript" src="js/lib/2.5.3-crypto-md5.js"></script>
 		<script type="text/javascript" src="js/lib/semver.browser.js"></script>
 		<script type="text/javascript" src="js/normalize.js"></script>

--- a/ccloader/index.html
+++ b/ccloader/index.html
@@ -1,5 +1,6 @@
 <html>
 	<head>
+		<script>!function(){var e="CCLOADER_OVERRIDE_MAIN_URL";window.process&&process.env&&process.env[e]&&window.location.replace(process.env[e])}();</script>
 		<title>CrossCode - CCLoader</title>
 		<link rel="stylesheet" href="index.css">
 		<script type="text/javascript">try{eval('() => {const x=0}')}catch(e){alert('Please use the "nwjs_new" version of CrossCode to use CCLoader!')}</script>

--- a/ccloader/js/ccloader.js
+++ b/ccloader/js/ccloader.js
@@ -6,7 +6,7 @@ import { Loader } from './loader.js';
 import { Plugin } from './plugin.js';
 import { Greenworks } from './greenworks.js';
 
-const CCLOADER_VERSION = '2.15.2';
+const CCLOADER_VERSION = '2.16.0';
 
 export class ModLoader {
 	constructor() {

--- a/ccloader/js/main.js
+++ b/ccloader/js/main.js
@@ -2,8 +2,10 @@ import './normalize.js';
 import { ModLoader } from './ccloader.js';
 
 if (window.process) {
-	var envVar = process.env.CCLOADER_OVERRIDE_MAIN_URL;
-	if (envVar) window.location.replace(envVar);
+	const envVar = process.env.CCLOADER_OVERRIDE_MAIN_URL;
+	if (envVar) {
+		window.location.replace(envVar);
+	}
 }
 
 window.onload = () => {

--- a/ccloader/js/main.js
+++ b/ccloader/js/main.js
@@ -1,4 +1,10 @@
+import './normalize.js';
 import { ModLoader } from './ccloader.js';
+
+if (window.process) {
+	var envVar = process.env.CCLOADER_OVERRIDE_MAIN_URL;
+	if (envVar) window.location.replace(envVar);
+}
 
 window.onload = () => {
 	const modloader = window.modloader = new ModLoader();

--- a/ccloader/package.json
+++ b/ccloader/package.json
@@ -3,5 +3,5 @@
 	"ccmodHumanName": "CCLoader",
 	"ccmodType": "base",
 	"description": "Modloader for CrossCode. This or a similar modloader is needed for most mods.",
-	"version": "2.15.2"
+	"version": "2.16.0"
 }


### PR DESCRIPTION
This patch is needed to reuse nw.js bundled with CC for mod development tools like CC map editor, it was proposed by me during a discussion about development of `cc-mod-manager-launcher` (now - `ccloader-installer`).