### PR TITLE
ccloader.js: Fix error message on postload fail.

### DIFF
--- a/ccloader/js/ccloader.js
+++ b/ccloader/js/ccloader.js
@@ -347,7 +347,7 @@ export class ModLoader {
 			try {
 				await mod.loadPostload();
 			} catch (e) {
-				console.error(`Could not run preload of mod '${mod.name}': `, e);
+				console.error(`Could not run postload of mod '${mod.name}': `, e);
 			}
 		}
 	}


### PR DESCRIPTION
The message reads "Could not run preload of..." instead
of "Could not run postload of...". Fix it, as it's confusing.