### PR TITLE
Some ccmod and browser fixes

### DIFF
--- a/ccloader/js/ccloader.js
+++ b/ccloader/js/ccloader.js
@@ -6,7 +6,7 @@ import { Loader } from './loader.js';
 import { Plugin } from './plugin.js';
 import { Greenworks } from './greenworks.js';
 
-const CCLOADER_VERSION = '2.18.3';
+const CCLOADER_VERSION = '2.18.4';
 
 export class ModLoader {
 	constructor() {

--- a/ccloader/js/filemanager.js
+++ b/ccloader/js/filemanager.js
@@ -125,7 +125,8 @@ export class Filemanager {
 	async loadServiceWorker(path, window) {
 		const currentRegistration = await window.navigator.serviceWorker.getRegistration();
 		if (currentRegistration) {
-			await currentRegistration.update();
+			//Do not await update since the worker only performs a simple task. Even if there is a bugfix it should be enough to not crash. 
+			currentRegistration.update();
 		} else {
 			await window.navigator.serviceWorker.register(path, {updateViaCache: 'none'});
 		}

--- a/ccloader/js/filemanager.js
+++ b/ccloader/js/filemanager.js
@@ -123,7 +123,12 @@ export class Filemanager {
 	 * @returns {Promise<ServiceWorker>}
 	 */
 	async loadServiceWorker(path, window) {
-		await window.navigator.serviceWorker.register(path, {updateViaCache: 'none'});
+		const currentRegistration = await window.navigator.serviceWorker.getRegistration();
+		if (currentRegistration) {
+			await currentRegistration.update();
+		} else {
+			await window.navigator.serviceWorker.register(path, {updateViaCache: 'none'});
+		}
 
 		if (!window.navigator.serviceWorker.controller || window.navigator.serviceWorker.controller.state !== 'activated') {
 			window.location.reload();

--- a/ccloader/js/filemanager.js
+++ b/ccloader/js/filemanager.js
@@ -176,7 +176,7 @@ export class Filemanager {
 
 		if(isLocal) {
 			return this._getResoucesInLocalFolder(folder, ending);
-		} else {
+		} else if (folder.endsWith('mods/')) {
 			var results = [];
 			for(var i in this.modList){
 				if(this._resourceExists(folder + this.modList[i] + ending)){
@@ -184,6 +184,10 @@ export class Filemanager {
 				}
 			}
 			return results;
+		} else {
+			if (this._resourceExists(folder + '/' + ending))
+				return [folder + '/' + ending];
+			return [];
 		}
 	}
 

--- a/ccloader/package.json
+++ b/ccloader/package.json
@@ -3,5 +3,5 @@
 	"ccmodHumanName": "CCLoader",
 	"ccmodType": "base",
 	"description": "Modloader for CrossCode. This or a similar modloader is needed for most mods.",
-	"version": "2.18.2"
+	"version": "2.18.4"
 }


### PR DESCRIPTION
Here are some browser and service worker fixes.

The first one fixes another browser issue with non-ccmod mods not finding package.json.

The second one is what prevented the ccmod version of Bob-Rank from working. To trigger this bug, one must play the game for like 5 minutes without triggering any request, then request a resource inside a ccmod. Bob-Rank was probably the only affected mod, because it loads some of its resources after 5 minutes of grinding in a loop to achieve S-Rank.

The third one forces the service worker to be reloaded, or else, applying the second patch will make the game fail to load once.