### PR TITLE
simplify: Fix running in a browser.

### DIFF
--- a/assets/mods/simplify/plugin.js
+++ b/assets/mods/simplify/plugin.js
@@ -70,8 +70,9 @@ export default class Simplify extends Plugin {
 	 * @returns {[string, string][]}
 	 */
 	_parseArgs() {
-		if (window.require) {
-			return require('nw.gui').App.argv.map(e => e.split('='));
+		const nwGui = window.require ? window.require('nw.gui') : null;
+		if (nwGui) {
+			return nwGui.App.argv.map(e => e.split('='));
 		} else {
 			return Array.from(new URL(window.parent.location.href).searchParams.entries())
 		}


### PR DESCRIPTION
simplify tries to check if it is running in a browser by attempting to
check for window.require.  But ccloader/js/normalize.js ensures that
window.require always exists, so the check always fails.

As a replacement, check that 'nw.gui' can be loaded.