### PR TITLE
Correctly handle asset paths in manifests as being relative to mod's assets directory

### DIFF
--- a/ccloader/js/ccloader.js
+++ b/ccloader/js/ccloader.js
@@ -5,7 +5,7 @@ import { Plugin } from './plugin.js';
 import { Greenworks } from './greenworks.js';
 import { Package } from './package.js';
 
-const CCLOADER_VERSION = '2.20.1';
+const CCLOADER_VERSION = '2.20.2';
 
 export class ModLoader {
 	constructor() {

--- a/ccloader/js/filemanager.js
+++ b/ccloader/js/filemanager.js
@@ -295,12 +295,21 @@ export class Filemanager {
 			if (await this._isDirectoryAsync(filePath)) {
 				return await this.findFiles(filePath, endings);
 			} else if (!endings || endings.some(ending => filePath.endsWith(ending))) {
-				return [filePath.substr(7).replace(/\\/g, '/')];
+				return [this.filePathToAssetPath(filePath)];
 			}
 			return [];
 		} catch (e) {
 			return [];
 		}
+	}
+
+	/**
+	 *
+	 * @param {string} filePath
+	 * @returns {string}
+	 */
+	filePathToAssetPath(filePath) {
+		return filePath.substr(7).replace(/\\/g, '/');
 	}
 
 	/**

--- a/ccloader/js/package.js
+++ b/ccloader/js/package.js
@@ -185,7 +185,7 @@ export class Package {
 	 * @param {string[] | undefined} list
 	 */
 	async _findAssets(dir, list){
-		if(!list || this.modloader.filemanager.isPacked(dir)){
+		if(window.isLocal || this.modloader.filemanager.isPacked(dir)){
 			return await this.modloader.filemanager.findFiles(dir, ['.json', '.json.patch', '.png', '.ogg']);
 		} else if (list) {
 			return list.map(asset => this.modloader.filemanager.filePathToAssetPath(dir + asset));

--- a/ccloader/js/package.js
+++ b/ccloader/js/package.js
@@ -185,20 +185,12 @@ export class Package {
 	 * @param {string[] | undefined} list
 	 */
 	async _findAssets(dir, list){
-		if(window.isLocal || this.modloader.filemanager.isPacked(dir)){
+		if(!list || this.modloader.filemanager.isPacked(dir)){
 			return await this.modloader.filemanager.findFiles(dir, ['.json', '.json.patch', '.png', '.ogg']);
+		} else if (list) {
+			return list.map(asset => this.modloader.filemanager.filePathToAssetPath(dir + asset));
 		} else {
-			const assets = list;
-			if (!assets) {
-				return [];
-			}
-			const base = this._getBaseName(this.file) + '/';
-
-			const result = [];
-			for(const asset of assets) {
-				result.push(base + asset);
-			}
-			return result;
+			return [];
 		}
 	}
 }

--- a/ccloader/package.json
+++ b/ccloader/package.json
@@ -3,5 +3,5 @@
 	"ccmodHumanName": "CCLoader",
 	"ccmodType": "base",
 	"description": "Modloader for CrossCode. This or a similar modloader is needed for most mods.",
-	"version": "2.20.1"
+	"version": "2.20.2"
 }


### PR DESCRIPTION
For context:

This PR has to do with handling of the `assets` field in mod manifests (both `ccmod.json` and `package.json`). For a long time (before `ccmod.json`, so only in `package.json`) it was assumed that the paths listed in this field are relative to the mod's root directory not to the mod's assets directory, so much so that this is how it had been implemented in CCLoader, and that we discussed this point when designing `ccmod.json`, and that I considered this while implementing CCLoader3 (spoiler: its implementation of `package.json` not affected by this PR). We have decided to improve this situation in `ccmod.json` by making the asset paths relative to the assets directory. However, since `ccmod.json` support was implemented in CCLoader2, I and (to my knowledge) @L-Sherry have discovered that it continues to treat asset paths in `ccmod.json` as relative to the root directory, thus making browser support tricky. This is due to the fact that the same function (`_findAssets`) was being used for collecting assets from mods with both `ccmod.json` and `package.json`. Which is, of course, a violation of the "specification" (imagine me making the harold face while writing this sentence). HOWEVER, apparently this field has been broken altogether ever since babe5f819bbbfc674d0885ff07f024a193d4a945, and that commit was made almost a year ago at this point. As such we have decided to fix path relativeness by making them relative to the assets directory in BOTH manifest formats, since in `package.json` it wasn't working in the first place for a while now.