### PR TITLE
allow virtual dependencies on extensions

### DIFF
--- a/ccloader/js/ccloader.js
+++ b/ccloader/js/ccloader.js
@@ -6,6 +6,7 @@ import { Greenworks } from './greenworks.js';
 import { Package } from './package.js';
 
 const CCLOADER_VERSION = '2.20.2';
+const KNOWN_EXTENSIONS = ["post-game", "manlea", "ninja-skin", "fish-gear", "flying-hedgehag", "scorpion-robo", "snowman-tank"]
 
 export class ModLoader {
 	constructor() {
@@ -257,25 +258,25 @@ export class ModLoader {
 			case 'crosscode':
 				depVersion = this.ccVersion;
 				break;
-			case 'post-game':
-			case 'manlea':
-			case 'ninja-skin':
-				depVersion = this.ccVersion;
-				isExtension = true;
-				break;
 			default:
-				depDesc = 'mod ' + depDesc;
-				mod = mods.find(m => m.name === depName);
-				if (mod) {
-					depVersion = mod.version;
-					enabled = mod.isEnabled;
+				if(KNOWN_EXTENSIONS.indexOf(depName) !== -1) {
+					isExtension = true;
+					depDesc = 'extension ' + depDesc;
+					depVersion = this.ccVersion;
+				} else {
+					depDesc = 'mod ' + depDesc;
+					mod = mods.find(m => m.name === depName);
+					if (mod) {
+						depVersion = mod.version;
+						enabled = mod.isEnabled;
+					}
 				}
 			}
 
-			if (!enabled) {
+			if (isExtension && this.extensions.indexOf(depName) === -1 ) {
+				result[depName] = `${depDesc} is missing`
+			} else if (!enabled) {
 				result[depName] = `${depDesc} is disabled`;
-			} else if (isExtension && this.extensions.indexOf(depName) === -1) {
-				result[depName] = `extension ${depDesc} is missing`
 			} else if (depVersion === null) {
 				result[depName] = `${depDesc} is missing`;
 			} else if (semver.valid(depVersion) === null) {

--- a/ccloader/js/ccloader.js
+++ b/ccloader/js/ccloader.js
@@ -259,7 +259,7 @@ export class ModLoader {
 				depVersion = this.ccVersion;
 				break;
 			default:
-				if(KNOWN_EXTENSIONS.indexOf(depName) !== -1) {
+				if(KNOWN_EXTENSIONS.includes(depName) || this.extensions.includes(depName)) {
 					isExtension = true;
 					depDesc = 'extension ' + depDesc;
 					depVersion = this.ccVersion;
@@ -273,7 +273,7 @@ export class ModLoader {
 				}
 			}
 
-			if (isExtension && this.extensions.indexOf(depName) === -1 ) {
+			if (isExtension && !this.extensions.includes(depName)) {
 				result[depName] = `${depDesc} is missing`
 			} else if (!enabled) {
 				result[depName] = `${depDesc} is disabled`;

--- a/ccloader/js/ccloader.js
+++ b/ccloader/js/ccloader.js
@@ -20,7 +20,8 @@ export class ModLoader {
 		this.mods = [];
 		/** @type {{[name: string]: string}} */
 		this.versions = {};
-
+		/** @type {string[]} */
+		this.extensions = this.filemanager.getExtensions();
 	}
 
 	/**
@@ -247,6 +248,7 @@ export class ModLoader {
 			let depVersion = null;
 			let enabled = true;
 			let depDesc = depName;
+			let isExtension = false;
 			let mod;
 			switch (depName) {
 			case 'ccloader':
@@ -254,6 +256,12 @@ export class ModLoader {
 				break;
 			case 'crosscode':
 				depVersion = this.ccVersion;
+				break;
+			case 'post-game':
+			case 'manlea':
+			case 'ninja-skin':
+				depVersion = this.ccVersion;
+				isExtension = true;
 				break;
 			default:
 				depDesc = 'mod ' + depDesc;
@@ -266,6 +274,8 @@ export class ModLoader {
 
 			if (!enabled) {
 				result[depName] = `${depDesc} is disabled`;
+			} else if (isExtension && this.extensions.indexOf(depName) === -1) {
+				result[depName] = `extension ${depDesc} is missing`
 			} else if (depVersion === null) {
 				result[depName] = `${depDesc} is missing`;
 			} else if (semver.valid(depVersion) === null) {

--- a/ccloader/js/filemanager.js
+++ b/ccloader/js/filemanager.js
@@ -178,11 +178,7 @@ export class Filemanager {
 	 * Returns an array of the extensions in 'assets/extensions'
 	 */
 	getExtensions() {
-		let extensionList = [];
-		this._getFolders('assets/extension').forEach(value => {
-			extensionList.push(value.substring(17))
-		})
-		return extensionList;
+		return this._getFolders('assets/extension').map(value => value.substr(17))
 	}
 
 	/**

--- a/ccloader/js/filemanager.js
+++ b/ccloader/js/filemanager.js
@@ -175,6 +175,17 @@ export class Filemanager {
 	}
 
 	/**
+	 * Returns an array of the extensions in 'assets/extensions'
+	 */
+	getExtensions() {
+		let extensionList = [];
+		this._getFolders('assets/extension').forEach(value => {
+			extensionList.push(value.substring(17))
+		})
+		return extensionList;
+	}
+
+	/**
 	 * Returns all files with the given ending in the folder
 	 * @param {string} folder
 	 */


### PR DESCRIPTION
This PR allows for a mod to place dependencies on currently three extensions (A New Home, as well as the Ninja/Manlea skins).

The dependencies are written just as normal mod dependencies are written - and uses the version number that CrossCode uses.

As for how it works - it simply checks what folders exist in `assets/extension`.

If there is anything missing or I did not account for - let me know.