### PR TITLE
Resolve CCLOADER_OVERRIDE_MAIN_URL relative to the game directory

### DIFF
--- a/ccloader/js/main.js
+++ b/ccloader/js/main.js
@@ -4,7 +4,7 @@ import { ModLoader } from './ccloader.js';
 if (window.process) {
 	const envVar = process.env.CCLOADER_OVERRIDE_MAIN_URL;
 	if (envVar) {
-		window.location.replace(envVar);
+		window.location.replace(new URL(envVar, window.location.origin));
 	}
 }
 


### PR DESCRIPTION
The previous behavior was that you had to specify a URL like `/some_tool/main.html` with a leading slash, so that it would be treated as an absolute URL, or else it would be resolved relative to modloader's `index.html`. Now URLs are really resolved as if they were literally written in `package.json`, thus specifying `some_tool/main.html` is possible. This is not a breaking change because ~~only two people remember about this feature~~ the previous working method of specifying the overridden URL continues to work.