### PR TITLE
Add patchstep "MERGE_CONTENT" (...and add 'v' to mod option version display)

### DIFF
--- a/assets/mods/simplify/lib/patch-steps-lib/src/patchsteps-patch.js
+++ b/assets/mods/simplify/lib/patch-steps-lib/src/patchsteps-patch.js
@@ -537,3 +537,11 @@ appliers["DEBUG"] = async function (state) {
 	state.debug = !!this["value"];
 };
 
+// combine the values of an object/array with another object/array. similar to non-patchstep patching.
+appliers["MERGE_CONTENT"] = async function (state) {
+	if (!("content" in this)) {
+		state.debugState.throwError("ValueError", 'content must be set');
+	}
+
+	photomerge(state.currentValue, this["content"]);
+}

--- a/assets/mods/simplify/mod.js
+++ b/assets/mods/simplify/mod.js
@@ -464,8 +464,12 @@
 						sizeY: 24,
 					};
 				}
+				
+				modOption.version = mod.version;
 
-				modOption.version = mod.version
+				if (modOption.version && !modOption.version.toLowerCase().startsWith("v")) {
+					modOption.version = "v" + modOption.version;
+				}
 
 				Object.defineProperty(sc.options[this.options.valuesName], optionName, {
 					get: () => localStorage.getItem(optionName) !== 'false',


### PR DESCRIPTION
MERGE_CONTENT would simply allow one to bulk add/modify many keys or array elements all at once.

To give an example, with an initial state of:
```json
{
    "a": 1,
    "b": 2
}
```
and a patchstep of:
```json
{
    "type": "MERGE_CONTENT",
    "content": {
        "a": 3,
        "c": 4
    }
}
```
It would modify the state to be:
```json
{
    "a": 3,
    "b": 2,
    "c": 4
}
```

For an array, it would work the same way - effectively acting as multiple `ADD_ARRAY_ELEMENT` to the end of the array. Functionally, it is identical to using `IMPORT` on a file holding the contents - removing the need to create a second file holding data to patch in, and also removing the need for multiple `SET_KEY` and `ADD_ARRAY_ELEMENT` patchsteps.

&nbsp;

As for the version display, it simply just adds a 'v' to the beginning of the version string. Probably not the more important part of this PR, but it seemed like a waste to do a whole PR over _just_ that.
![image](https://user-images.githubusercontent.com/49847844/160475519-347bc2e0-fe54-4fca-a4b8-c8d2b62d9e32.png)
