### PR TITLE
Remove --auto-open-devtools-for-tabs from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "CrossCode",
   "version" : "0.2.3",
   "main": "ccloader/index.html",
-  "chromium-args" : "--ignore-gpu-blacklist --disable-direct-composition --disable-background-networking --in-process-gpu --password-store=basic --auto-open-devtools-for-tabs",
+  "chromium-args" : "--ignore-gpu-blacklist --disable-direct-composition --disable-background-networking --in-process-gpu --password-store=basic",
   "window" : {
 	"toolbar" : false,
 	"icon" : "favicon.png",


### PR DESCRIPTION
Fixes #105 
I've had to remove this option from `package.json` when creating a CrossedEyes `.zip` bundle, because I've had the same issue