### PR TITLE
Don't throw a caught error when checking if a mod has asset files

### DIFF
--- a/ccloader/js/filemanager.js
+++ b/ccloader/js/filemanager.js
@@ -273,10 +273,10 @@ export class Filemanager {
 			})).json();
 		}
 
-		return new Promise((resolve, reject) => {
+		return new Promise((resolve) => {
 			this.fs.readdir(dir, (err, files) => {
 				if (err) {
-					reject(err);
+					resolve([]);
 				} else {
 					resolve(files);
 				}


### PR DESCRIPTION
This removes a very annoying behavior in a common scenario:
You're trying to debug an error with your mod with "Pause on caught
exceptions" on, you reload the game, and this error pops out.